### PR TITLE
Add support for downloading to an absolute or relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Default value: `''`
 
 Sets the provisioning profile that you want to use for code signing your iOS app.
 
+#### options.destination
+Type: `String`
+Default value: `''`
+
+Sets the destination for the file if the download switch is set.
+This can be either an absolute path or a path relative to the project's Gruntfile.
+
 ### Usage Examples
 
 ```js

--- a/tasks/appbuilder.js
+++ b/tasks/appbuilder.js
@@ -8,6 +8,9 @@
 
 'use strict';
 
+var path = require('path');
+var fs = require('fs');
+
 module.exports = function(grunt) {
     grunt.registerMultiTask('appbuilder', 'Grunt task to execute the Telerik AppBuilder CLI', function() {
         var done = this.async(),
@@ -19,8 +22,15 @@ module.exports = function(grunt) {
             download: true,
             companion: false,
             certificate: '',
-            provision: ''
+            provision: '',
+            destination: '',
         });
+
+        var dest = path.resolve(options.destination);
+        var dir = path.dirname(dest);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir);
+        }
 
         this.files.forEach(function(file) {
             var src = file.src.filter(function(filepath) {
@@ -33,7 +43,7 @@ module.exports = function(grunt) {
                 }
             }).join(' ');
 
-            build(src, file.dest, options, function (results) {
+            build(src, options.destination.length > 0 ? dest : file.dest, options, function (results) {
                 if(results === false) {
                     done(false);
                 } else {


### PR DESCRIPTION
This PR adds support for a 'destination' option which, if set, will allow the downloaded build files to be saved to a specific location, instead of in the root directory of the project. Ensuring that this download location exists is also handled automatically, as is relative path resolution.

Thanks for your work on this project, and let me know if you'd like to see any changes.
